### PR TITLE
recalculate new and updated collections each time an update is run

### DIFF
--- a/lib/browse_pages.rb
+++ b/lib/browse_pages.rb
@@ -22,7 +22,7 @@ class BrowsePages
     create_browse_table(browse_pages_db)
     browse_pages_table = browse_pages_db[:browse_pages]
     browse_page_ids_and_titles = browse_pages_table.to_hash(:id, :title)
-    browse_page_new_page_colls = browse_pages_table.filter(:status => "new").or(:status => "updated").to_has(:id, :title)
+    browse_page_new_page_colls = browse_pages_table.filter(:status => "new").or(:status => "updated").to_hash(:id, :title)
     browse_pages_db.disconnect
 
     aspace_colls = CrudHelpers.scoped_dataset(Resource, {:publish => true})

--- a/lib/browse_pages.rb
+++ b/lib/browse_pages.rb
@@ -20,8 +20,9 @@ class BrowsePages
 
     browse_pages_db = Sequel.connect(AppConfig[:browse_page_db_url])
     create_browse_table(browse_pages_db)
-    browse_page_ids_and_titles = browse_pages_db[:browse_pages].to_hash(:id, :title)
-    browse_page_new_page_colls = browse_pages[:browse_pages].filter(:status => "new").or(:status => "updated").to_has(:id, :title)
+    browse_pages_table = browse_pages_db[:browse_pages]
+    browse_page_ids_and_titles = browse_pages_table.to_hash(:id, :title)
+    browse_page_new_page_colls = browse_pages_table.filter(:status => "new").or(:status => "updated").to_has(:id, :title)
     browse_pages_db.disconnect
 
     aspace_colls = CrudHelpers.scoped_dataset(Resource, {:publish => true})


### PR DESCRIPTION
this recalculates the new/updated status for collections currently on the new and updated collections page each time an update is run, otherwise collections would stay on the new and updated page until a change was made to that collection in ArchivesSpace.